### PR TITLE
feat: 무한스크롤 상품 리스트 완성

### DIFF
--- a/src/components/ProductList.js
+++ b/src/components/ProductList.js
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+import Product from "./Product";
+
+const ProductListWrapper = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(25%, 25%));
+`;
+
+function ProductList({ products }) {
+  return (
+    <>
+      <ProductListWrapper>
+        {products.map((product) => (
+          <Product product={product} key={product.id} />
+        ))}
+      </ProductListWrapper>
+    </>
+  );
+}
+
+export default ProductList;

--- a/src/pages/ProductPage.js
+++ b/src/pages/ProductPage.js
@@ -1,5 +1,70 @@
+import { useSelector } from "react-redux";
+import ProductList from "../components/ProductList";
+import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+
+const ProductPageWrapper = styled.div`
+  width: 1080px;
+  height: 100%;
+  margin: 0 auto;
+  margin-top: 4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
 function ProductPage() {
-  return <></>;
+  const ITEMS_PER_ROW = 4;
+  const ROWS_PER_SCROLL = 3;
+
+  if (!localStorage.getItem("currentIndex")) localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
+  let currentIndex = Number(localStorage.getItem("currentIndex"));
+
+  const productList = useSelector((state) => state.productList);
+  const [currentList, setCurrentList] = useState([]);
+  const [isEnd, setIsEnd] = useState(false);
+
+  const handleScroll = () => {
+    const scrollHeight = document.documentElement.scrollHeight;
+    const scrollTop = document.documentElement.scrollTop;
+    const clientHeight = document.documentElement.clientHeight;
+
+    if (scrollTop + clientHeight >= scrollHeight) {
+      setIsEnd(true);
+    }
+  };
+
+  const addNextData = () => {
+    if (isEnd) {
+      setCurrentList([...currentList, ...productList.slice(currentIndex, currentIndex + ITEMS_PER_ROW * ROWS_PER_SCROLL)]);
+      localStorage.setItem("currentIndex", currentIndex + ITEMS_PER_ROW * ROWS_PER_SCROLL);
+      setIsEnd(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
+    };
+  }, []);
+
+  useEffect(() => {
+    setCurrentList(productList.slice(0, currentIndex));
+  }, [productList]);
+
+  useEffect(() => {
+    addNextData();
+  }, [isEnd]);
+
+  return (
+    <ProductPageWrapper>
+      <ProductList products={currentList} />
+    </ProductPageWrapper>
+  );
 }
 
 export default ProductPage;


### PR DESCRIPTION
이미 서버에서 전체 데이터를 받아왔기 때문에 '상품리스트 상태'에 저장해놓은 것을 불러오고,
리스트에 렌더링 할 배열은 '현재리스트 상태'입니다.

자바스크립트 스크롤 이벤트 이용하여
스크롤 끝점 감지 시 상품리스트를 slice하여 '현재리스트 상태'에 재할당합니다.
데이터는 12개씩 추가됩니다.

'현재리스트 상태' 업데이트 시 slice는 로컬스토리지에 저장된 currentIndex를 이용
(업데이트되면 currentIndex는 currentIndex+12로 업데이트)
slice(0, 12), .slice(12, 24), .slice(24, 36) ...
currentIndex는 컴포넌트 언마운트시 로컬스토리지에 12로 초기화합니다.

현재 useEffect를 많이 사용하여 컴포넌트가 6번씩 렌더링됩니다.
추후 방법을 생각해보고 개선할 예정입니다.