### PR TITLE
feat: 상품리스트 페이지 및 북마크 페이지 완성

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,8 +1,6 @@
 import styled from "@emotion/styled";
 
 const FooterWrapper = styled.footer`
-  position: absolute;
-  bottom: 0;
   z-index: 1;
   background-color: var(--white);
   display: flex;

--- a/src/components/SubPageTemplate.js
+++ b/src/components/SubPageTemplate.js
@@ -1,0 +1,82 @@
+import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+import FilterList from "./FilterList";
+import ProductList from "./ProductList";
+
+const SubPageWrapper = styled.div`
+  width: 1080px;
+  height: 100%;
+  margin: 0 auto;
+  margin-top: 4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+function SubPageTemplate({ baseList }) {
+  const ITEMS_PER_ROW = 4;
+  const ROWS_PER_SCROLL = 3;
+
+  if (!localStorage.getItem("currentIndex")) localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
+  let currentIndex = Number(localStorage.getItem("currentIndex"));
+
+  const [filteredList, setFilteredList] = useState([]);
+  const [currentList, setCurrentList] = useState([]);
+  const [isEnd, setIsEnd] = useState(false);
+
+  const handleScroll = () => {
+    const scrollHeight = document.documentElement.scrollHeight;
+    const scrollTop = document.documentElement.scrollTop;
+    const clientHeight = document.documentElement.clientHeight;
+
+    if (scrollTop + clientHeight >= scrollHeight) {
+      setIsEnd(true);
+    }
+  };
+
+  const addNextData = () => {
+    if (isEnd) {
+      setCurrentList([...currentList, ...filteredList.slice(currentIndex, currentIndex + ITEMS_PER_ROW * ROWS_PER_SCROLL)]);
+      localStorage.setItem("currentIndex", currentIndex + ITEMS_PER_ROW * ROWS_PER_SCROLL);
+      setIsEnd(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
+    };
+  }, []);
+
+  useEffect(() => {
+    setFilteredList(baseList);
+  }, [baseList]);
+
+  useEffect(() => {
+    localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
+    currentIndex = Number(localStorage.getItem("currentIndex"));
+    setCurrentList(filteredList.slice(0, currentIndex));
+  }, [filteredList]);
+
+  useEffect(() => {
+    addNextData();
+  }, [isEnd]);
+
+  const handleFilterClick = (type) => {
+    if (type === "All") setFilteredList(baseList);
+    else setFilteredList(baseList.filter((product) => product.type === type));
+  };
+
+  return (
+    <SubPageWrapper>
+      <FilterList handleFilterClick={handleFilterClick} />
+      <ProductList products={currentList} />
+    </SubPageWrapper>
+  );
+}
+
+export default SubPageTemplate;

--- a/src/pages/BookmarkPage.js
+++ b/src/pages/BookmarkPage.js
@@ -1,5 +1,13 @@
+import { useSelector } from "react-redux";
+import SubPageTemplate from "../components/SubPageTemplate";
+
 function BookmarkPage() {
-  return <></>;
+  const bookmarkList = useSelector((state) => state.bookmarkList);
+  return (
+    <>
+      <SubPageTemplate baseList={bookmarkList} />
+    </>
+  );
 }
 
 export default BookmarkPage;

--- a/src/pages/ProductPage.js
+++ b/src/pages/ProductPage.js
@@ -1,84 +1,10 @@
 import { useSelector } from "react-redux";
-import ProductList from "../components/ProductList";
-import styled from "@emotion/styled";
-import { useEffect, useState } from "react";
-import FilterList from "../components/FilterList";
-
-const ProductPageWrapper = styled.div`
-  width: 1080px;
-  height: 100%;
-  margin: 0 auto;
-  margin-top: 4rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-`;
+import SubPageTemplate from "../components/SubPageTemplate";
 
 function ProductPage() {
-  const ITEMS_PER_ROW = 4;
-  const ROWS_PER_SCROLL = 3;
-
-  if (!localStorage.getItem("currentIndex")) localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
-  let currentIndex = Number(localStorage.getItem("currentIndex"));
-
   const productList = useSelector((state) => state.productList);
-  const [filteredList, setFilteredList] = useState([]);
-  const [currentList, setCurrentList] = useState([]);
-  const [isEnd, setIsEnd] = useState(false);
 
-  const handleScroll = () => {
-    const scrollHeight = document.documentElement.scrollHeight;
-    const scrollTop = document.documentElement.scrollTop;
-    const clientHeight = document.documentElement.clientHeight;
-
-    if (scrollTop + clientHeight >= scrollHeight) {
-      setIsEnd(true);
-    }
-  };
-
-  const addNextData = () => {
-    if (isEnd) {
-      setCurrentList([...currentList, ...filteredList.slice(currentIndex, currentIndex + ITEMS_PER_ROW * ROWS_PER_SCROLL)]);
-      localStorage.setItem("currentIndex", currentIndex + ITEMS_PER_ROW * ROWS_PER_SCROLL);
-      setIsEnd(false);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener("scroll", handleScroll);
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-      localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
-    };
-  }, []);
-
-  useEffect(() => {
-    setFilteredList(productList);
-  }, [productList]);
-
-  useEffect(() => {
-    localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
-    currentIndex = Number(localStorage.getItem("currentIndex"));
-    setCurrentList(filteredList.slice(0, currentIndex));
-  }, [filteredList]);
-
-  useEffect(() => {
-    addNextData();
-  }, [isEnd]);
-
-  const handleFilterClick = (type) => {
-    if (type === "All") setFilteredList(productList);
-    else setFilteredList(productList.filter((product) => product.type === type));
-  };
-
-  return (
-    <ProductPageWrapper>
-      <FilterList handleFilterClick={handleFilterClick} />
-      <ProductList products={currentList} />
-    </ProductPageWrapper>
-  );
+  return <SubPageTemplate baseList={productList} />;
 }
 
 export default ProductPage;


### PR DESCRIPTION
처음에 ProductPage에 구현하였던 상품리스트 페이지 구조가 북마크 페이지 구조와 같아서 SubPageTemplate으로 컴포넌트화하여 렌더링할 리스트를 props로 전달해주도록 변경하였습니다.

Footer컴포넌트 위치를 페이지 맨 밑으로 가도록 스타일링을 수정했습니다.

## 메인페이지
![화면 기록 2023-05-18 오후 1 12 27](https://github.com/hahagarden/fe-sprint-coz-shopping/assets/88613455/4376766a-ad9d-40a0-876a-88ffb52a6214)

## 상품리스트 페이지
![화면 기록 2023-05-18 오후 1 14 19](https://github.com/hahagarden/fe-sprint-coz-shopping/assets/88613455/01374db2-8014-43ee-b42c-5f974a84f9f8)

## 북마크 페이지
![화면 기록 2023-05-18 오후 1 18 53](https://github.com/hahagarden/fe-sprint-coz-shopping/assets/88613455/b0054a4e-3aa3-4e83-ba47-7f08af01708d)

