### PR TITLE
fix: 전체 스타일링 수정, 한번에 불러오는 데이터 개수 수정

### DIFF
--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -17,9 +17,10 @@ const FilterText = styled.div`
   margin-top: 8px;
 `;
 
-function Filter({ filterOption, handleFilterClick }) {
+function Filter({ filterOption, handleFilterClick, className }) {
   return (
     <FilterWrapper
+      className={className}
       onClick={() => {
         handleFilterClick(filterOption.type);
       }}

--- a/src/components/FilterList.js
+++ b/src/components/FilterList.js
@@ -10,11 +10,13 @@ const filterOptions = {
 };
 
 const FilterListWrapper = styled.div`
-  width: 50%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   padding: 30px 0;
+  & > div:not(:first-child) {
+    margin-left: 1.5rem;
+  }
 `;
 
 function FilterList({ handleFilterClick }) {

--- a/src/components/FilterList.js
+++ b/src/components/FilterList.js
@@ -19,12 +19,25 @@ const FilterListWrapper = styled.div`
   }
 `;
 
+const ClickedFilter = styled(Filter)`
+  & > div {
+    font-weight: 600;
+    color: var(--purple);
+  }
+`;
+
 function FilterList({ handleFilterClick }) {
+  const currentFilter = localStorage.getItem("filterOption");
+
   return (
     <FilterListWrapper>
-      {Object.values(filterOptions).map((option) => (
-        <Filter key={option.type} filterOption={option} handleFilterClick={handleFilterClick} />
-      ))}
+      {Object.values(filterOptions).map((option) => {
+        return currentFilter === option.type ? (
+          <ClickedFilter key={option.type} filterOption={option} handleFilterClick={handleFilterClick} />
+        ) : (
+          <Filter key={option.type} filterOption={option} handleFilterClick={handleFilterClick} />
+        );
+      })}
     </FilterListWrapper>
   );
 }

--- a/src/components/MainProductList.js
+++ b/src/components/MainProductList.js
@@ -3,8 +3,6 @@ import Product from "./Product";
 
 const MainProductListWrapper = styled.div`
   width: 100%;
-  display: flex;
-  flex-direction: column;
 `;
 
 const Title = styled.h2`
@@ -12,12 +10,10 @@ const Title = styled.h2`
 `;
 
 const List = styled.div`
-  height: 16rem;
-  display: flex;
-
-  & > div:not(:first-of-type) {
-    margin-left: 1rem;
-  }
+  width: 100%;
+  display: grid;
+  column-gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(20%, auto));
 `;
 
 function MainProductList({ products, type }) {

--- a/src/components/Product.js
+++ b/src/components/Product.js
@@ -6,8 +6,8 @@ import { add } from "../redux/modalDataSlice";
 const ProductWrapper = styled.div``;
 
 const ProductContainer = styled.div`
-  width: 16rem;
-  height: 16rem;
+  width: 100%;
+  aspect-ratio: 4/3;
   flex: none;
   cursor: pointer;
 `;

--- a/src/components/ProductList.js
+++ b/src/components/ProductList.js
@@ -4,7 +4,8 @@ import Product from "./Product";
 const ProductListWrapper = styled.div`
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(25%, 25%));
+  column-gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(20%, auto));
 `;
 
 function ProductList({ products }) {

--- a/src/components/SubPageTemplate.js
+++ b/src/components/SubPageTemplate.js
@@ -4,7 +4,8 @@ import FilterList from "./FilterList";
 import ProductList from "./ProductList";
 
 const SubPageWrapper = styled.div`
-  width: 1080px;
+  width: 100vw;
+  padding: 0 100px;
   height: 100%;
   margin: 0 auto;
   margin-top: 4rem;

--- a/src/components/SubPageTemplate.js
+++ b/src/components/SubPageTemplate.js
@@ -17,10 +17,9 @@ const SubPageWrapper = styled.div`
 `;
 
 function SubPageTemplate({ baseList }) {
-  const ITEMS_PER_ROW = 4;
-  const ROWS_PER_SCROLL = 3;
+  const DATA_PER_PAGE = 30;
 
-  if (!localStorage.getItem("currentIndex")) localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
+  if (!localStorage.getItem("currentIndex")) localStorage.setItem("currentIndex", DATA_PER_PAGE);
   let currentIndex = Number(localStorage.getItem("currentIndex"));
 
   const [filteredList, setFilteredList] = useState([]);
@@ -39,8 +38,8 @@ function SubPageTemplate({ baseList }) {
 
   const addNextData = () => {
     if (isEnd) {
-      setCurrentList([...currentList, ...filteredList.slice(currentIndex, currentIndex + ITEMS_PER_ROW * ROWS_PER_SCROLL)]);
-      localStorage.setItem("currentIndex", currentIndex + ITEMS_PER_ROW * ROWS_PER_SCROLL);
+      setCurrentList([...currentList, ...filteredList.slice(currentIndex, currentIndex + DATA_PER_PAGE)]);
+      localStorage.setItem("currentIndex", currentIndex + DATA_PER_PAGE);
       setIsEnd(false);
     }
   };
@@ -50,7 +49,7 @@ function SubPageTemplate({ baseList }) {
     if (!localStorage.getItem("filterOption")) localStorage.setItem("filterOption", "All");
     return () => {
       window.removeEventListener("scroll", handleScroll);
-      localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
+      localStorage.setItem("currentIndex", DATA_PER_PAGE);
       localStorage.setItem("filterOption", "All");
     };
   }, []);
@@ -61,7 +60,7 @@ function SubPageTemplate({ baseList }) {
   }, [baseList]);
 
   useEffect(() => {
-    localStorage.setItem("currentIndex", ITEMS_PER_ROW * ROWS_PER_SCROLL);
+    localStorage.setItem("currentIndex", DATA_PER_PAGE);
     currentIndex = Number(localStorage.getItem("currentIndex"));
     setCurrentList(filteredList.slice(0, currentIndex));
   }, [filteredList]);

--- a/src/components/SubPageTemplate.js
+++ b/src/components/SubPageTemplate.js
@@ -6,12 +6,13 @@ import ProductList from "./ProductList";
 const SubPageWrapper = styled.div`
   width: 100vw;
   padding: 0 100px;
+  padding-bottom: 30px;
   height: 100%;
+  min-height: calc(100vh - 8rem);
   margin: 0 auto;
   margin-top: 4rem;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
 `;
 

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -3,13 +3,14 @@ import MainProductList from "../components/MainProductList";
 import styled from "@emotion/styled";
 
 const MainPageWrapper = styled.div`
-  width: 1080px;
+  width: 100vw;
+  padding: 0 100px;
   height: calc(100vh - 8rem);
   margin: 0 auto;
   margin-top: 4rem;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-evenly;
   align-items: center;
 `;
 


### PR DESCRIPTION
- 전체 크기 스타일링 수정
- Footer 위치 수정
- 불러오는 데이터 개수 수정
![coz스타일전](https://github.com/hahagarden/fe-sprint-coz-shopping/assets/88613455/e1c1c090-3fe6-404d-a15a-0d2e32deed25)
다른 모니터에서 프로젝트를 실행해보니 크기가 맞지 않았습니다. 노트북에서는 데이터를 12개만 불러와도 화면이 꽉 찼는데 해상도가 큰 모니터에서는 모자랐습니다. 

![반응형](https://github.com/hahagarden/fe-sprint-coz-shopping/assets/88613455/4ee84fa2-7fd5-461f-ad86-dda9ff1f5e30)
반응형으로 수정하였고 불러오는 데이터 개수를 30개로 늘렸습니다.


- 클릭된 필터 스타일링 추가
![필터스타일](https://github.com/hahagarden/fe-sprint-coz-shopping/assets/88613455/4a9aac35-e91b-4f4f-a447-8bf89e4cb758)
