### PR TITLE
fix: 필터상태를 로컬스토리지에서 useState로 변경에 따른 클릭된 필터 스타일링 수정

### DIFF
--- a/src/components/FilterList.js
+++ b/src/components/FilterList.js
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import Filter from "./Filter";
-import { Types, StorageKey } from "../utils/enum";
-import { getLocalStorage } from "../utils/func";
+import { Types } from "../utils/enum";
 
 const filterOptions = {
   all: { type: Types.ALL, title: "전체", imgUrl: `${process.env.PUBLIC_URL}/public_assets/filter_all.png` },
@@ -28,9 +27,7 @@ const ClickedFilter = styled(Filter)`
   }
 `;
 
-function FilterList({ handleFilterClick }) {
-  const currentFilter = getLocalStorage(StorageKey.FILTER_OPTION);
-
+function FilterList({ currentFilter, handleFilterClick }) {
   return (
     <FilterListWrapper>
       {Object.values(filterOptions).map((option) => {

--- a/src/components/SubPageTemplate.js
+++ b/src/components/SubPageTemplate.js
@@ -57,7 +57,7 @@ function SubPageTemplate({ baseList }) {
 
   return (
     <SubPageWrapper>
-      <FilterList handleFilterClick={handleFilterClick} />
+      <FilterList currentFilter={currentFilter} handleFilterClick={handleFilterClick} />
       <ProductList products={currentList} />
     </SubPageWrapper>
   );


### PR DESCRIPTION
이전 커밋 https://github.com/hahagarden/fe-sprint-coz-shopping/commit/1bcd934ec8d29fa0ebe43fb19b3dc98d5c41fb70 에서 로컬스토리지에 저장하던 filterOption을 useState를 사용한 currentFilter 상태로 수정하였기 때문에  
이에 따라 currentFilter상태를 props drilling하는 것으로 수정하였습니다.